### PR TITLE
Hooks and permissions redesign

### DIFF
--- a/docs/fundamentals/permissions.md
+++ b/docs/fundamentals/permissions.md
@@ -186,7 +186,7 @@ Let's say that we would like to restrict `Instructor`s to accessing course that 
 ```heavenly-x
 acl {
     role Instructor {
-        allow ALL Course(auth.courseBelongsToInstructor)
+        allow ALL Course @attributeBased(auth.courseBelongsToInstructor)
         allow ALL Student
     }
 }
@@ -197,10 +197,10 @@ The `auth.courseBelongsToInstructor` is a JavaScript function imported from a Ja
 ```heavenly-x
 acl {
     role Instructor {
-        allow ALL Course(auth.courseBelongsToInstructor)
+        allow ALL Course @attributeBased(auth.courseBelongsToInstructor)
         allow ALL Student
     }
 }
 ```
 
-> **Note:** The same requirement can be satisfied using the `@ifOwner` directive but we used predicates in this example to demonstrate how you can define attribute-based access rules
+> **Note:** The same requirement can be satisfied using the `@ifOwner` directive but we used the `@attributeBased` directive in this example to demonstrate how you can define attribute-based access rules


### PR DESCRIPTION
## Changes
1. Added two new keywords that one of them must be added before every access rule. `allow` and `deny`
2. Renamed `permit` to `acl`
3. Added two rule-level directives. `@ifOwner` and `@ifSelf`
4. Added a rule-level `@attributeBased(hook: ExternalFunction)` for attribute-based access-control

## Justifications

#### Why `deny` and `allow` keywords
1. Clarity of requirements and better readability
2. Sometimes the developer might need to add a global access rule that allows access to a certain resource for every role on the system but deny access for one roles

#### Why renaming the `permit` block to `acl`?
We need a more generic name for the block after adding the `permit` and `deny` block

#### Why `@ifOwner` and `@ifSelf` directives?
1. Better UX:
It's true that the developer can implement the functionality of these directives using attribute-based access controls (authorization hooks) but after doing multiple examples I found that these two functionalities are very common and it's easier for the developer to have them as built-in directives.

2. Better Performance:
Also, this way we can make the functionality of these directives more performant than relying on executing a hook on every request since they are very common use cases. 

#### Why `@attributeBased` instead of the previous syntax?
For syntactic consistency